### PR TITLE
extend celebrity detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,16 +194,17 @@ docker run --rm -d -p 5000:5000 caryyu/douban-openapi-server:<commit>
   ➜ curl -s http://localhost:5000/movies/1295038/celebrities | jq
   [
     {
-      "id": "1049716",
-      "img": "https://img3.doubanio.com/view/celebrity/s_ratio_celebrity/public/p10680.jpg",
-      "name": "克里斯·哥伦布",
-      "role": "导演"
-    },
-    {
-      "id": "1003484",
-      "img": "https://img3.doubanio.com/view/celebrity/s_ratio_celebrity/public/p30800.jpg",
-      "name": "丹尼尔·雷德克里夫",
-      "role": "演员"
+      "id": "1027347",
+      "img": "https://img9.doubanio.com/view/celebrity/s_ratio_celebrity/public/p1477093490.04.jpg",
+      "name": "伊恩·哈特",
+      "role": "演员",
+      "intro": "伊恩·哈特（Ian Hart），1964年10月8日出生于英国利物浦。英国男演员。曾在哈利·波特的第一部《哈利·波特与魔法石》中扮演了奇洛教授，被中国观众所熟知。作为英国戏剧界一位知名的演员，他还曾经成功地扮演过约翰·列侬。",
+      "gender": "男",
+      "constellation": "天秤座",
+      "birthdate": "1964-10-08",
+      "birthplace": "英国,英格兰,默西塞德郡,利物浦",
+      "nickname": "Ian Davies",
+      "imdb": "nm0001324"
     }
   ]
   ```


### PR DESCRIPTION
Extend the API of `/movies/<sid>/celebrities` by fetching more detailed pages and combine results together

- Limit number of celebrities to `8` in order to prevent reaching the rate-limiting by Douban
- Only handle Directors and Actors 