### PR TITLE
add swagger support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ WORKDIR /app
 RUN pip install pipenv
 RUN pipenv install 
 
-ENTRYPOINT ["pipenv", "run", "gunicorn", "-w", "3", "-b", "0.0.0.0:5000", "app:app"]
+ENTRYPOINT ["pipenv", "run", "gunicorn", "-w", "3", "-b", "0.0.0.0:5000", "--access-logfile", "-", "app:app"]
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) caryyu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ flask-caching = "*"
 requests = "*"
 beautifulsoup4 = "*"
 flask-restful = "*"
+flasgger = "*"
 
 [dev-packages]
 autopep8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "762f57a56121c5e65c458f296e160722d94040cf2e92a1102422c3f82e05c883"
+            "sha256": "8306e41d4415502a2856e3864acb56df9d381a61988dfad65c7c709aa89683dd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,6 +22,14 @@
                 "sha256:72e3117667eedf66951bb2d93f4296a56b94b078a8a95905a052611fb3f1b973"
             ],
             "version": "==9.0.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
         },
         "beautifulsoup4": {
             "hashes": [
@@ -70,6 +78,14 @@
             ],
             "index": "pypi",
             "version": "==0.31.0"
+        },
+        "flasgger": {
+            "hashes": [
+                "sha256:0603941cf4003626b4ee551ca87331f1d17b8eecce500ccf1a1f1d3a332fc94a",
+                "sha256:6ebea406b5beecd77e8da42550f380d4d05a6107bc90b69ce9e77aee7612e2d0"
+            ],
+            "index": "pypi",
+            "version": "==0.9.5"
         },
         "flask": {
             "hashes": [
@@ -216,6 +232,13 @@
             "markers": "python_version >= '3.6'",
             "version": "==3.0.1"
         },
+        "jsonschema": {
+            "hashes": [
+                "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163",
+                "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
+            ],
+            "version": "==3.2.0"
+        },
         "markupsafe": {
             "hashes": [
                 "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
@@ -256,12 +279,61 @@
             "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
         },
+        "mistune": {
+            "hashes": [
+                "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e",
+                "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"
+            ],
+            "version": "==0.8.4"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.17.3"
+        },
         "pytz": {
             "hashes": [
                 "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
                 "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
             ],
             "version": "==2021.1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
         },
         "requests": {
             "hashes": [

--- a/app.py
+++ b/app.py
@@ -1,4 +1,6 @@
 import json
+
+from flasgger import Swagger
 from resource.celebrity_resource import Celebrity
 from resource.movie_resource import Movie, MovieCelebrityList, MovieList
 
@@ -24,6 +26,24 @@ api.add_resource(MovieList, '/movies', resource_class_kwargs=options)
 api.add_resource(Movie, '/movies/<sid>', resource_class_kwargs=options)
 api.add_resource(MovieCelebrityList, '/movies/<sid>/celebrities', resource_class_kwargs=options)
 api.add_resource(Celebrity, '/celebrities/<cid>', resource_class_kwargs=options)
+
+swagger_config = {
+    "headers": [
+    ],
+    "specs": [
+        {
+            "endpoint": 'apispec',
+            "route": '/apispec.json',
+            "rule_filter": lambda rule: True,  # all in
+            "model_filter": lambda tag: True,  # all in
+        }
+    ],
+    "static_url_path": "/flasgger_static",
+    # "static_folder": "static",  # must be set by user
+    "swagger_ui": True,
+    "specs_route": "/"
+}
+swagger = Swagger(app, config=swagger_config, template_file='docs/default.yml')
 
 @app.route('/search', methods=['GET'])
 # @cache.cached(timeout=30, query_string=True)

--- a/docs/celebrity.yml
+++ b/docs/celebrity.yml
@@ -1,0 +1,14 @@
+Query a celebrity by its id
+---
+tags:
+  - Celebrity
+parameters:
+  - name: cid
+    in: path
+    type: string
+    required: true
+responses:
+  200:
+    description: A Celebrity object
+    schema:
+      $ref: '#/definitions/Celebrity'

--- a/docs/default.yml
+++ b/docs/default.yml
@@ -1,19 +1,21 @@
 swagger: "2.0"
 info:
   title: "Douban Open API"
-  description: "An unofficial API server"
+  description: "An unofficial API server for Douban"
   contact:
     responsibleOrganization: "individual"
     responsibleDeveloper: "caryyu"
     email: "caryyu.tg@gmail.com"
     url: "github.com/caryyu"
-  termsOfService: "http://me.com/terms"
+  termsOfService: "http://swagger.io/terms/"
   version: "0.0.1"
+  license:
+    name: "MIT"
+    url: "https://github.com/caryyu/douban-openapi-server/blob/main/LICENSE"
 host: "localhost:5000"
 basePath: "/"
 schemes:
   - "http"
-  - "https"
 definitions:
   Celebrity:
     type: object

--- a/docs/default.yml
+++ b/docs/default.yml
@@ -1,0 +1,67 @@
+swagger: "2.0"
+info:
+  title: "Douban Open API"
+  description: "An unofficial API server"
+  contact:
+    responsibleOrganization: "individual"
+    responsibleDeveloper: "caryyu"
+    email: "caryyu.tg@gmail.com"
+    url: "github.com/caryyu"
+  termsOfService: "http://me.com/terms"
+  version: "0.0.1"
+host: "localhost:5000"
+basePath: "/"
+schemes:
+  - "http"
+  - "https"
+definitions:
+  Celebrity:
+    type: object
+    properties:
+      id:
+        type: string
+      img:
+        type: string
+      name:
+        type: string
+      role:
+        type: string
+  Movie:
+    type: object
+    properties:
+      name:
+        type: string
+      rating:
+        type: string
+      img:
+        type: string
+      sid:
+        type: string
+      year:
+        type: string
+      intro:
+        type: string
+      director:
+        type: string
+      actor:
+        type: string
+      genre:
+        type: string
+      site:
+        type: string
+      country:
+        type: string
+      language:
+        type: string
+      screen:
+        type: string
+      duration:
+        type: string
+      subname:
+        type: string
+      imdb:
+        type: string
+      celebrities:
+        type: array
+        items:
+          $ref: '#/definitions/Celebrity'

--- a/docs/movie-celebrity-list.yml
+++ b/docs/movie-celebrity-list.yml
@@ -1,0 +1,16 @@
+Query a movie celebrity list by a movie id
+---
+tags:
+  - Movie
+parameters:
+  - name: sid
+    in: path
+    type: string
+    required: true
+responses:
+  200:
+    description: A list of celebrities
+    schema:
+      type: array
+      items:
+        $ref: '#/definitions/Celebrity'

--- a/docs/movie-celebrity-list.yml
+++ b/docs/movie-celebrity-list.yml
@@ -1,7 +1,7 @@
 Query a movie celebrity list by a movie id
 ---
 tags:
-  - Movie
+  - Celebrity
 parameters:
   - name: sid
     in: path

--- a/docs/movie-list.yml
+++ b/docs/movie-list.yml
@@ -1,0 +1,23 @@
+Query a movie list by a keyword
+---
+tags:
+  - Movie
+parameters:
+  - name: type
+    in: query
+    type: string
+    enum: ['full', 'partial']
+    required: false
+    default: partial
+  - name: q
+    in: query
+    type: string
+    required: true
+    default: 'Harry Potter'
+responses:
+  200:
+    description: A list of movies
+    schema:
+      type: array
+      items:
+        $ref: '#/definitions/Movie'

--- a/docs/movie.yml
+++ b/docs/movie.yml
@@ -1,0 +1,14 @@
+Query a movie by its id
+---
+tags:
+  - Movie
+parameters:
+  - name: sid
+    in: path
+    type: string
+    required: true
+responses:
+  200:
+    description: A movie object
+    schema:
+      $ref: '#/definitions/Movie'

--- a/resource/celebrity_resource.py
+++ b/resource/celebrity_resource.py
@@ -1,6 +1,8 @@
 from resource.base_resource import BaseResource
+from flasgger import swag_from
 
 class Celebrity(BaseResource):
+    @swag_from('../docs/celebrity.yml')
     def get(self, cid):
         headers = {'content-type': 'application/json'}
         self.logger.info('the parameter is given: %s', cid)

--- a/resource/general_resource.py
+++ b/resource/general_resource.py
@@ -1,0 +1,1 @@
+# Anything that's unrelated to the media resources can be put here

--- a/resource/movie_resource.py
+++ b/resource/movie_resource.py
@@ -1,8 +1,10 @@
 from resource.base_resource import BaseResource
 from flask_restful import Resource, reqparse
+from flasgger import swag_from
 
 class MovieList(BaseResource):
 
+    @swag_from('../docs/movie-list.yml')
     def get(self):
         parser = reqparse.RequestParser()
         parser.add_argument('type', type=str)
@@ -40,6 +42,7 @@ class MovieList(BaseResource):
         return f'Results Not Found: {keyword}', 404, headers
 
 class Movie(BaseResource):
+    @swag_from('../docs/movie.yml')
     def get(self, sid):
         return self.__api_fetch_by_sid(sid)
 
@@ -56,6 +59,7 @@ class Movie(BaseResource):
         return f'Results Not Found: {sid}', 404, headers
 
 class MovieCelebrityList(BaseResource):
+    @swag_from('../docs/movie-celebrity-list.yml')
     def get(self, sid):
         return self.__api_fetch_celerities_by_sid(sid)
 


### PR DESCRIPTION
By leveraging `flasgger` to support Swagger, which gives a more standard approach to host API instructions, in addition to this, the overall features are:

- Dockerfile has been enabled Gunicorn access log printing
- Write those open api yaml files