### PR TITLE
Docker: A non-root user to lower the risk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM python:3.9.4-slim
 
-ADD . /app
-WORKDIR /app
+# Install packages globally
+COPY Pipfile .
+COPY Pipfile.lock .
+RUN pip install pipenv \
+    && pipenv install --deploy --system \
+    && rm -f Pipfile Pipfile.lock
 
-RUN pip install pipenv
-RUN pipenv install 
+# Access restriction by a non-root account
+RUN useradd --create-home dos
+WORKDIR /home/dos
+USER dos
 
-ENTRYPOINT ["pipenv", "run", "gunicorn", "-w", "3", "-b", "0.0.0.0:5000", "--access-logfile", "-", "app:app"]
-
+ADD --chown=dos:dos . /var/lib/app
+ENTRYPOINT ["gunicorn", "-w", "3", "-b", "0.0.0.0:5000", "--access-logfile", "-", "--chdir", "/var/lib/app", "app:app"]


### PR DESCRIPTION
As a root user sometimes could help hackers possess a `superadmin` permission from containers' zero-day bug, this approach is going to lower the risk of that by Linux native user privilege management, the issue reference originated from https://github.com/caryyu/douban-openapi-server/issues/10