### PR TITLE
Enable start-args overridable from port issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ WORKDIR /home/dos
 USER dos
 
 ADD --chown=dos:dos . /var/lib/app
-ENTRYPOINT ["gunicorn", "-w", "3", "-b", "0.0.0.0:5000", "--access-logfile", "-", "--chdir", "/var/lib/app", "app:app"]
+ENTRYPOINT ["gunicorn"]
+CMD ["-w", "3", "-b", "0.0.0.0:5000", "--access-logfile", "-", "--chdir", "/var/lib/app", "app:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ WORKDIR /home/dos
 USER dos
 
 ADD --chown=dos:dos . /var/lib/app
-ENTRYPOINT ["gunicorn"]
-CMD ["-w", "3", "-b", "0.0.0.0:5000", "--access-logfile", "-", "--chdir", "/var/lib/app", "app:app"]
+ENTRYPOINT ["gunicorn", "--access-logfile", "-", "--chdir", "/var/lib/app", "-w", "3"]
+CMD ["-b", "0.0.0.0:5000", "app:app"]


### PR DESCRIPTION
https://github.com/caryyu/douban-openapi-server/issues/15

Usage: 
> docker run --rm -d --host caryyu/douban-openapi-server:latest -b 0.0.0.0:5000 app:app
